### PR TITLE
fixed seg fault

### DIFF
--- a/src/lexing.c
+++ b/src/lexing.c
@@ -102,7 +102,7 @@ t_token	*lexing(t_ms *shell)
 		i++;
 	}
 	if (check_parse_error(shell))
-		return (lex_free(args), free_tokens(head), NULL);
+		return (null_fds(head), lex_free(args), free_tokens(head), NULL);
 	if (DEBUG)
 		print_tokens(head);
 	return (null_fds(head), lex_free(args), head);


### PR DESCRIPTION
It was only necessary to nullify unitialised value in order to prevent segmentation fault.